### PR TITLE
Fixes listing with only 1 record

### DIFF
--- a/src/ArchivesExtension.php
+++ b/src/ArchivesExtension.php
@@ -84,6 +84,7 @@ class ArchivesExtension extends SimpleExtension
      */
     public function archiveList(Application $app, $contenttypeslug, $period)
     {
+        $config = $this->getConfig();
         $contentTypeName = $contenttypeslug;
         // Scrub, scrub.
         $period = preg_replace('/[^0-9-]+/', '', $period);
@@ -125,7 +126,11 @@ class ArchivesExtension extends SimpleExtension
 
         // Fetch the records, based on the ids we gathered earlier. Doing it this way
         // allows us to keep the sorting intact, as well as skip unpublished records.
-        $records = (array) $app['storage']->getContent($contentType['slug'], ['id' => implode(' || ', $ids)]);
+        $records = $app['storage']->getContent($contentType['slug'], ['id' => implode(' || ', $ids)]);
+        
+        if (count($records) === 1) {
+            $records = [$records];
+        }
 
         // Get the correct template
         if (!empty($config['template'])) {


### PR DESCRIPTION
The listing page was broken when only 1 record was matching the selected month / year.

This should also fix #11 and #12 => $config was not initialized in the archiveList method.
